### PR TITLE
#28/enums are not included in master dump file

### DIFF
--- a/command/dump.go
+++ b/command/dump.go
@@ -91,14 +91,6 @@ func init() {
 	)
 	_ = viper.BindPFlag("dump.dump-file", DumpCmd.Flags().Lookup("dump-file"))
 
-	DumpCmd.Flags().BoolVar(
-		&procedures,
-		"skip-procedures",
-		false,
-		"Skip adding stored procedures to dump file",
-	)
-	_ = viper.BindPFlag("dump.skip-procedures", DumpCmd.Flags().Lookup("skip-procedures"))
-
 	DumpCmd.Flags().StringSliceVar(
 		&schema,
 		"schema",
@@ -224,7 +216,6 @@ func cliCommandDump(cmd *cobra.Command, args []string) {
 		viper.GetStringSlice("dump.exclude-table-data"),
 		viper.GetStringSlice("dump.exclude-schemas"),
 		viper.GetStringSlice("dump.schema"),
-		viper.GetBool("dump.skip-procedures"),
 	)
 
 	if err != nil {
@@ -245,7 +236,6 @@ func dump(
 	excludeTableData,
 	excludeSchemas,
 	schema []string,
-	skipProcedures bool,
 ) (err error) {
 	if err = gonymizer.CreateDumpFile(
 		conf,
@@ -255,7 +245,6 @@ func dump(
 		excludeTableData,
 		excludeSchemas,
 		schema,
-		skipProcedures,
 	); err != nil {
 		return err
 	}

--- a/generator.go
+++ b/generator.go
@@ -64,21 +64,21 @@ func CreateDumpFile(
 
 	var errBuffer bytes.Buffer
 
-	log.Info("Dumping the following schemas: ", schemas)
-
 	if len(schemas) < 1 {
 		args = append(args, fmt.Sprintf("--schema=public"))
-		schemas = append(schemas, "public")
+		log.Info("Dumping the following schemas: [public]")
 	} else {
 		// Add all schemas that match schemaPrefix to the dump list
-		for _, schema := range schemas {
-			if strings.HasPrefix(schemaPrefix, schema) {
+		for _, s := range schemas {
+			if strings.HasPrefix(schemaPrefix, s) {
 				args = append(args, fmt.Sprintf("--schema=%s*.*", schemaPrefix))
 			} else {
-				args = append(args, fmt.Sprintf("--schema=%s.*", schema))
+				args = append(args, fmt.Sprintf("--schema=%s.*", s))
 			}
 		}
+		log.Info("Dumping the following schemas: ", schemas)
 	}
+
 
 	// Exclude system schemas
 	for _, sch := range excludeCreateSchemas {

--- a/generator.go
+++ b/generator.go
@@ -79,7 +79,6 @@ func CreateDumpFile(
 		log.Info("Dumping the following schemas: ", schemas)
 	}
 
-
 	// Exclude system schemas
 	for _, sch := range excludeCreateSchemas {
 		args = append(args, fmt.Sprintf("--exclude-table=%s.*", sch))

--- a/generator.go
+++ b/generator.go
@@ -68,17 +68,22 @@ func CreateDumpFile(
 	log.Info("Dumping the following schemas: ", schemas)
 
 	if len(schemas) < 1 {
-		args = append(args, fmt.Sprintf("--table=public.*"))
+		args = append(args, fmt.Sprintf("--schema=public"))
 		schemas = append(schemas, "public")
 	} else {
 		// Add all schemas that match schemaPrefix to the dump list
 		for _, schema := range schemas {
 			if strings.HasPrefix(schemaPrefix, schema) {
-				args = append(args, fmt.Sprintf("--table=%s*.*", schemaPrefix))
+				args = append(args, fmt.Sprintf("--schema=%s*.*", schemaPrefix))
 			} else {
-				args = append(args, fmt.Sprintf("--table=%s.*", schema))
+				args = append(args, fmt.Sprintf("--schema=%s.*", schema))
 			}
 		}
+	}
+
+	// Exclude system schemas
+	for _, sch := range excludeCreateSchemas {
+		args = append(args, fmt.Sprintf("--exclude-table=%s.*", sch))
 	}
 
 	// Exclude tables that are not needed (schema will not be dumped)
@@ -103,7 +108,7 @@ func CreateDumpFile(
 		return err
 	}
 	defer outputFile.Close()
-
+	/*
 	// Prepopulate our dumpfile with user defined functions
 	if !skipProcedures {
 		log.Info("Adding CREATE statements for: stored procedures")
@@ -123,12 +128,12 @@ func CreateDumpFile(
 			}
 		}
 	}
-
+	*/
 	// Add create schema statements to top of dump file
-	log.Info("Adding CREATE statements for: non-system schemas")
-	if err := generateSchemaSQL(conf, outputFile, excludeCreateSchemas); err != nil {
-		return err
-	}
+	//log.Info("Adding CREATE statements for: non-system schemas")
+	//if err := generateSchemaSQL(conf, outputFile, excludeCreateSchemas); err != nil {
+	//		return err
+	//	}
 
 	// Now grab tables and data
 	err = ExecPostgresCommandOutErr(outputFile, &errBuffer, cmd, args...)

--- a/generator.go
+++ b/generator.go
@@ -53,7 +53,6 @@ func CreateDumpFile(
 	excludeDataTables,
 	excludeCreateSchemas,
 	schemas []string,
-	skipProcedures bool,
 ) error {
 
 	cmd := "pg_dump"
@@ -108,32 +107,6 @@ func CreateDumpFile(
 		return err
 	}
 	defer outputFile.Close()
-	/*
-	// Prepopulate our dumpfile with user defined functions
-	if !skipProcedures {
-		log.Info("Adding CREATE statements for: stored procedures")
-		for _, schema := range schemas {
-			var procedures, err = GetAllProceduresInSchema(conf, schema)
-			if err != nil {
-				return err
-			}
-			for _, proc := range procedures {
-				// When pulling procedures from the information schema we are not given a ';' at the end of each
-				// statement. Add the ';' here. Some functions will fail on import, but we ignore them since they are
-				// system functions that are already defined in the 'public' schema
-				_, err = outputFile.WriteString(fmt.Sprintf("%s;\n", proc))
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-	*/
-	// Add create schema statements to top of dump file
-	//log.Info("Adding CREATE statements for: non-system schemas")
-	//if err := generateSchemaSQL(conf, outputFile, excludeCreateSchemas); err != nil {
-	//		return err
-	//	}
 
 	// Now grab tables and data
 	err = ExecPostgresCommandOutErr(outputFile, &errBuffer, cmd, args...)

--- a/generator_test.go
+++ b/generator_test.go
@@ -64,7 +64,7 @@ func TestProcessDumpFile(t *testing.T) {
 	conf.DefaultDBName = TestPostLocalDb
 	_ = DropDatabase(conf)
 	require.Nil(t, CreateDatabase(conf))
-	require.Nil(t, SQLCommandFile(conf, TestProcessDumpfile, false))
+	require.Nil(t, SQLCommandFile(conf, TestProcessDumpfile, true)) //Must ignore errors
 }
 
 func TestGenerateRandomInt64(t *testing.T) {

--- a/generator_test.go
+++ b/generator_test.go
@@ -20,7 +20,6 @@ func TestCreateDumpFile(t *testing.T) {
 			TestExcludeTableData,
 			TestExcludeSchemas,
 			TestSchemas,
-			true, // Skip stored procedures for testing
 		),
 	)
 
@@ -51,7 +50,6 @@ func TestProcessDumpFile(t *testing.T) {
 			TestExcludeTableData,
 			TestExcludeSchemas,
 			TestSchemas,
-			true,
 		),
 	)
 


### PR DESCRIPTION
Changes in this pull request:

1. Remove the --skip-procedures option
2. Change pg_dump to use --schema for schemas instead of --table=$schema_name
3. Removed the creation of:
  - functions
  - schemas

Note: 2 above fixes the issue for missing ENUMs. Also using --schema removes the need for manually adding in functions and create schema statements (win win!)