### PR TITLE
Noticed the project license has a copy/paste error in it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 Then please do not open an issue here yet - you should first try one of the following support forums:
 
- - irc: #gonymizer on freenode
+ - Slack: https://smith-oss.slack.com
 
 ## Reporting an issue properly
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2013-2018 Docker, Inc.
+   Copyright 2018-2019 SmithRx, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
This was a copy/paste error from when I copied over the Apache 2 LICENSE.txt file from the Docker Moby project. Just noticed it today when grepping for "docker" in the directory.