### PR TITLE
Add processor for state abbreviations

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Below is a list of fake data creators and scramblers. This table may not be up t
 | FakeLastName | Used to replace a person's last name with a fake last name
 | FakePhoneNumber | Used to replace a person's phone number with fake phone number
 | FakeState | Used to replace a state (full state name, non-abbreviated)
+| FakeStateAbbrev | Used to replace a state abbreviation
 | FakeUsername | Used to replace a username with a fake one
 | FakeZip | Used to replace a real zip code with another zip code
 | Identity | Used to notify Gonymizer **not** to anonymize the column (same as leaving the column out of the map file)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/cobra v0.0.5 // indirect
-	github.com/spf13/viper v1.4.0 // indirect
+	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	golang.org/x/crypto v0.0.0-20190506204251-e1dfcc566284

--- a/processors.go
+++ b/processors.go
@@ -66,6 +66,7 @@ func init() {
 		"FakeLastName":          ProcessorLastName,
 		"FakePhoneNumber":       ProcessorPhoneNumber,
 		"FakeState":             ProcessorState,
+		"FakeStateAbbrev":       ProcessorStateAbbrev,
 		"FakeUsername":          ProcessorUserName,
 		"FakeZip":               ProcessorZip,
 		"Identity":              ProcessorIdentity, // Default: Does not modify field
@@ -162,6 +163,11 @@ func ProcessorPhoneNumber(cmap *ColumnMapper, input string) (string, error) {
 // ProcessorState will return a state that is >= 0.4 Jaro-Winkler similar than the input.
 func ProcessorState(cmap *ColumnMapper, input string) (string, error) {
 	return fake.State(), nil
+}
+
+// ProcessorStateAbbrev will return a state abbreviation.
+func ProcessorStateAbbrev(cmap *ColumnMapper, input string) (string, error) {
+	return fake.StateAbbrev(), nil
 }
 
 // ProcessorUserName will return a username that is >= 0.4 Jaro-Winkler similar than the input.

--- a/processors_test.go
+++ b/processors_test.go
@@ -149,6 +149,17 @@ func TestProcessorState(t *testing.T) {
 	require.NotEqual(t, output, "")
 }
 
+func TestProcessorStateAbbrev(t *testing.T) {
+	output, err := ProcessorStateAbbrev(&cMap, "NY")
+	require.Nil(t, err)
+	require.NotEqual(t, output, "NY")
+
+	output, err = ProcessorStateAbbrev(&cMap, "")
+	require.Nil(t, err)
+	require.NotEqual(t, output, "")
+	require.Len(t, output, 2)
+}
+
 func TestProcessorUserName(t *testing.T) {
 	output, err := ProcessorUserName(&cMap, "Ricky and Julian")
 	require.Nil(t, err)


### PR DESCRIPTION
This PR adds a new processor to generate state abbreviations (NY, MD, etc).

The processor uses `fake`'s built-in function `StateAbbrev()`.