### PR TITLE
Provide docker login password through stdin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
             go mod download
       - run:
           name: Docker Login
-          command: docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASS
+          command: echo $DOCKER_HUB_PASS | docker login -u $DOCKER_HUB_USER --password-stdin
       - run:
           name: Build Gonymizer Image
           command: |


### PR DESCRIPTION
This PR changes the docker login to provide password through `STDIN` to prevent the password from ending up in the shell's history or log-files.

Signed-off-by: Oliver Tso <olivertsor@gmail.com>