### PR TITLE
Fix docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!cmd
+!*.go
+!go.mod
+!go.sum

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,19 @@
 ### BUILD ###
 #############
 FROM golang:1.13-alpine as build
-ENV GO111MODULE=on
-RUN apk update && apk upgrade && apk add --no-cache bash git gcc go linux-headers musl-dev postgresql curl
-RUN mkdir -p /tmp/gonymizer/
+RUN apk update && apk upgrade && apk add --no-cache gcc musl-dev postgresql
 RUN mkdir -p /tmp/gonymizer/bin
 WORKDIR /tmp/gonymizer/
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
 COPY . .
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GOFLAGS=-mod=vendor go build -v -ldflags '-w -extldflags "-static"' -o bin/gonymizer ./cmd/...
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -v -ldflags '-w -extldflags "-static"' -o bin/gonymizer ./cmd/...
 
 ##########################
 ### Gonymizer Runtime  ###
 ##########################
 FROM golang:1.13-alpine as gonymizer
-RUN apk update && apk upgrade && apk add --no-cache postgresql curl
+RUN apk update && apk upgrade && apk add --no-cache postgresql
 
 COPY --from=build /tmp/gonymizer/bin/gonymizer /usr/bin/gonymizer


### PR DESCRIPTION
This PR
- removes the vendor flag;
- removes `GO111MODULE=on` as starting from go 1.13 `GO111MODULE=auto` enables module-mode if `go.mod` is found;
- removes unused packages;
- adds `.dockerignore`.

Close #63 