### PR TITLE
Add docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ docs/demos/dellstore2/dellstore2-normal-1.0
 
 # Test files
 db_test_*.log
+output.Test*
+
+# Test coverage
+coverage.out
 
 # IntelliJ Idea
 .idea
@@ -18,4 +22,3 @@ db_test_*.log
 # Demo SQL/Log files
 docs/demos/dellstore2/*.sql
 docs/demos/dellstore2/*.log
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3.7"
+
+services:
+  bin:
+    build:
+      context: .
+      target: gonymizer
+    volumes:
+      - type: bind
+        source: ./testing
+        target: /go/testing
+    depends_on:
+      - db
+
+  test:
+    build:
+      context: .
+      target: build
+    command:
+      - go
+      - test
+      - -v
+      - -cover
+      - -coverprofile=coverage.out
+      - -run
+      - TestStart
+    environment:
+      POSTGRES_HOST: db
+      POSTGRES_USER: gonymizer
+    volumes:
+      - type: bind
+        source: ./testing
+        target: /tmp/gonymizer/testing
+    depends_on:
+      - db
+
+  db:
+    image: postgres:11-alpine
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: gonymizer
+    volumes:
+      - type: volume
+        source: dbdata
+        target: /var/lib/postgresql/data
+
+volumes:
+  dbdata:

--- a/main_test.go
+++ b/main_test.go
@@ -57,8 +57,13 @@ var (
 
 // GetTestDbConf will return a PGConfig for the specified localhost testing database.
 func GetTestDbConf(dbName string) PGConfig {
+	host, ok := os.LookupEnv("POSTGRES_HOST")
+	if !ok {
+		host = "localhost"
+	}
 	conf := PGConfig{}
-	conf.Host = "localhost"
+	conf.Username = os.Getenv("POSTGRES_USER")
+	conf.Host = host
 	conf.DefaultDBName = dbName
 	conf.SSLMode = "disable"
 	return conf

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+docker-compose run --rm "$@"


### PR DESCRIPTION
Closes #20 

This PR adds a docker compose file to enable us to:
- run tests with `scripts/run.sh test`;
- run gonymizer commands with `scripts/run.sh bin gonymizer <command> <flags>`.

Not sure if this is the expected. Please let me know if there's any suggestion or anything I'm missing, thanks!