### PR TITLE
Fix AlphaNumericScrambler typo on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Below is a list of fake data creators and scramblers. This table may not be up t
 
 | Processor Name | Use |
 | -------------- |:----|
-| AlphaNumbericScrambler | Scrambles strings. If a number is in the string it will replace it with another random number
+| AlphaNumericScrambler | Scrambles strings. If a number is in the string it will replace it with another random number
 | EmptyJson | Replaces a JSON with an empty one (`{}`)
 | FakeStreetAddress | Used to replace a real US address with a fake one
 | FakeCity | Used to replace a city column


### PR DESCRIPTION
There is a typo on the `README.md` list of available processors, where `AlphaNum*b*ericScrambler` should be `AlphaNumericScrambler`.

Small fix but it may trip some people up.