### PR TITLE
Exit when the config is incorrect

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -185,6 +185,9 @@ func initConfig() {
 
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	} else if err != nil && viper.ConfigFileUsed() != "" {
+		fmt.Println("Failed to open config file:", err.Error())
+		os.Exit(1)
 	}
 
 	// 2. Load ENV variables


### PR DESCRIPTION
Rather than continue we exit if we fail to read the config. This is
because the config contains information about connection to database and
without it gonymizer can't work correctly. It now also prints out the
relevant error.