### PR TITLE
Retain backslash escape sequences

### DIFF
--- a/processors.go
+++ b/processors.go
@@ -336,7 +336,7 @@ func scrambleString(input string) string {
 		switch c := input[i]; {
 		case c == '\\':
 			b.WriteByte(c)
-			i = passEscapeSequence(b, input, i+1)
+			i = passEscapeSequence(b.WriteByte, input, i+1)
 		case c >= 'a' && c <= 'z':
 			b.WriteString(randomLowercase())
 		case c >= 'A' && c <= 'Z':
@@ -358,32 +358,32 @@ func scrambleString(input string) string {
 // - numeric sequences of lengths shorter than expected
 // as more of a responsibility of the producer and consumer.
 // We return index of the last consumed input character.
-func passEscapeSequence(b strings.Builder, input string, i int) int {
+func passEscapeSequence(write func(c byte) error, input string, i int) int {
 	c := input[i]
-	b.WriteByte(c)
+	write(c)
 	switch {
 	case c >= '0' && c <= '7':
-		i = passOctalSequence(b, input, i+1)
+		i = passOctalSequence(write, input, i+1)
 	case c == 'x':
-		i = passHexadecimalSequence(b, input, i, 2)
+		i = passHexadecimalSequence(write, input, i, 2)
 	case c == 'u':
-		i = passHexadecimalSequence(b, input, i, 4)
+		i = passHexadecimalSequence(write, input, i, 4)
 	case c == 'U':
-		i = passHexadecimalSequence(b, input, i, 8)
+		i = passHexadecimalSequence(write, input, i, 8)
 	}
 	return i
 }
 
-func passOctalSequence(b strings.Builder, input string, i int) int {
+func passOctalSequence(write func(c byte) error, input string, i int) int {
 	for endAt := i + 2; i < endAt && i < len(input) && input[i] >= '0' && input[i] <= '7'; i++ {
-		b.WriteByte(input[i])
+		write(input[i])
 	}
 	return i - 1
 }
 
-func passHexadecimalSequence(b strings.Builder, input string, i int, maxlen int) int {
+func passHexadecimalSequence(write func(c byte) error, input string, i int, maxlen int) int {
 	for endAt := i + maxlen; i < endAt && i < len(input) && isHexadecimalCharacter(input[i]); i++ {
-		b.WriteByte(input[i])
+		write(input[i])
 	}
 	return i - 1
 }

--- a/processors.go
+++ b/processors.go
@@ -377,7 +377,7 @@ func passEscapeSequence(write func(c byte) error, input string, i int) int {
 func passOctalSequence(write func(c byte) error, input string, i int) int {
 	for endAt := i + 2; i < endAt && i < len(input); i++ {
 		c := input[i]
-		if input[i] < '0' || input[i] > '7' {
+		if c < '0' || c > '7' {
 			break
 		}
 		write(c)

--- a/processors.go
+++ b/processors.go
@@ -334,6 +334,9 @@ func scrambleString(input string) string {
 
 	for i := 0; i < len(input); i++ {
 		switch c := input[i]; {
+		case c == '\\':
+			b.WriteByte(c)
+			i = passEscapeSequence(b, input, i+1)
 		case c >= 'a' && c <= 'z':
 			b.WriteString(randomLowercase())
 		case c >= 'A' && c <= 'Z':
@@ -346,6 +349,47 @@ func scrambleString(input string) string {
 	}
 
 	return b.String()
+}
+
+// Retain escapes sequences such as \n, \xHH as they are.
+// See https://www.postgresql.org/docs/current/sql-syntax-lexical.html
+// We liberally accept
+// - any escaped character as is
+// - numeric sequences of lengths shorter than expected
+// as more of a responsibility of the producer and consumer.
+// We return index of the last consumed input character.
+func passEscapeSequence(b strings.Builder, input string, i int) int {
+	c := input[i]
+	b.WriteByte(c)
+	switch {
+	case c >= '0' && c <= '7':
+		i = passOctalSequence(b, input, i+1)
+	case c == 'x':
+		i = passHexadecimalSequence(b, input, i, 2)
+	case c == 'u':
+		i = passHexadecimalSequence(b, input, i, 4)
+	case c == 'U':
+		i = passHexadecimalSequence(b, input, i, 8)
+	}
+	return i
+}
+
+func passOctalSequence(b strings.Builder, input string, i int) int {
+	for endAt := i + 2; i < endAt && i < len(input) && input[i] >= '0' && input[i] <= '7'; i++ {
+		b.WriteByte(input[i])
+	}
+	return i - 1
+}
+
+func passHexadecimalSequence(b strings.Builder, input string, i int, maxlen int) int {
+	for endAt := i + maxlen; i < endAt && i < len(input) && isHexadecimalCharacter(input[i]); i++ {
+		b.WriteByte(input[i])
+	}
+	return i - 1
+}
+
+func isHexadecimalCharacter(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F')
 }
 
 // scrubString replaces the input string with asterisks (*) and returns it as the output.

--- a/processors.go
+++ b/processors.go
@@ -365,11 +365,11 @@ func passEscapeSequence(write func(c byte) error, input string, i int) int {
 	case c >= '0' && c <= '7':
 		i = passOctalSequence(write, input, i+1)
 	case c == 'x':
-		i = passHexadecimalSequence(write, input, i, 2)
+		i = passHexadecimalSequence(write, input, i+1, 2)
 	case c == 'u':
-		i = passHexadecimalSequence(write, input, i, 4)
+		i = passHexadecimalSequence(write, input, i+1, 4)
 	case c == 'U':
-		i = passHexadecimalSequence(write, input, i, 8)
+		i = passHexadecimalSequence(write, input, i+1, 8)
 	}
 	return i
 }
@@ -382,8 +382,12 @@ func passOctalSequence(write func(c byte) error, input string, i int) int {
 }
 
 func passHexadecimalSequence(write func(c byte) error, input string, i int, maxlen int) int {
-	for endAt := i + maxlen; i < endAt && i < len(input) && isHexadecimalCharacter(input[i]); i++ {
-		write(input[i])
+	for endAt := i + maxlen; i < endAt && i < len(input); i++ {
+		c := input[i]
+		if !isHexadecimalCharacter(c) {
+			break
+		}
+		write(c)
 	}
 	return i - 1
 }

--- a/processors.go
+++ b/processors.go
@@ -375,8 +375,12 @@ func passEscapeSequence(write func(c byte) error, input string, i int) int {
 }
 
 func passOctalSequence(write func(c byte) error, input string, i int) int {
-	for endAt := i + 2; i < endAt && i < len(input) && input[i] >= '0' && input[i] <= '7'; i++ {
-		write(input[i])
+	for endAt := i + 2; i < endAt && i < len(input); i++ {
+		c := input[i]
+		if input[i] < '0' || input[i] > '7' {
+			break
+		}
+		write(c)
 	}
 	return i - 1
 }

--- a/processors_test.go
+++ b/processors_test.go
@@ -58,6 +58,11 @@ func TestProcessorAlphaNumericScrambler(t *testing.T) {
 	require.NotEqual(t, outputA, outputB)
 	// outputA === outputC
 	require.Equal(t, outputA, outputC)
+
+	const escapeSequences = "\\\\\\t\\n\\f\\b\\1\\21\\337\\x1\\xF2\\u4AE1\\UDEADBEEF"
+	outputEscapes, err := ProcessorAlphaNumericScrambler(&alphaTest, escapeSequences)
+	require.Nil(t, err)
+	require.Equal(t, outputEscapes, escapeSequences)
 }
 
 func TestProcessorAddress(t *testing.T) {

--- a/processors_test.go
+++ b/processors_test.go
@@ -2,6 +2,7 @@ package gonymizer
 
 import (
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -59,10 +60,23 @@ func TestProcessorAlphaNumericScrambler(t *testing.T) {
 	// outputA === outputC
 	require.Equal(t, outputA, outputC)
 
-	const escapeSequences = "\\\\\\t\\n\\f\\b\\1\\21\\337\\x1\\xF2\\u4AE1\\UDEADBEEF"
-	outputEscapes, err := ProcessorAlphaNumericScrambler(&alphaTest, escapeSequences)
-	require.Nil(t, err)
-	require.Equal(t, outputEscapes, escapeSequences)
+	escapeSequences := [...]string{"\\\\", "\\t", "\\n", "\\f", "\\b", "\\1", "\\21", "\\337", "\\x1", "\\xF2", "\\u4AE1", "\\UDEAFBEEF"}
+	for i := 0; i < len(escapeSequences); i++ {
+		outputEscaped, err := ProcessorAlphaNumericScrambler(&alphaTest, escapeSequences[i])
+		require.Nil(t, err)
+		require.Equal(t, escapeSequences[i], outputEscaped)
+	}
+
+	completeEscapeSequences := [...]string{"\\\\", "\\t", "\\n", "\\f", "\\b", "\\337", "\\xF2", "\\u4AE1", "\\UDEAFBEEF"}
+	const suffix = "12345"
+	for i := 0; i < len(completeEscapeSequences); i++ {
+		input := completeEscapeSequences[i] + suffix
+		outputEscaped, err := ProcessorAlphaNumericScrambler(&alphaTest, input)
+		require.Nil(t, err)
+		require.Equal(t, len(outputEscaped), len(input))
+		require.True(t, strings.HasPrefix(outputEscaped, completeEscapeSequences[i]))
+		require.False(t, strings.HasSuffix(outputEscaped, suffix))
+	}
 }
 
 func TestProcessorAddress(t *testing.T) {


### PR DESCRIPTION
Pass sequences escaped by backslash as they are in the database dump in order to avoid producing invalid input for the database restore. This could happen eg. when '\n123' was converted to '\x971'.