### PR TITLE
update to go 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #############
 ### BUILD ###
 #############
-FROM golang:1.13-alpine as build
+FROM golang:1.15-alpine as build
 RUN apk update && apk upgrade && apk add --no-cache gcc musl-dev postgresql
 RUN mkdir -p /tmp/gonymizer/bin
 WORKDIR /tmp/gonymizer/
@@ -14,7 +14,7 @@ RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -v -ldflags '-w -extldflags "
 ##########################
 ### Gonymizer Runtime  ###
 ##########################
-FROM golang:1.13-alpine as gonymizer
+FROM golang:1.15-alpine as gonymizer
 RUN apk update && apk upgrade && apk add --no-cache postgresql
 
 COPY --from=build /tmp/gonymizer/bin/gonymizer /usr/bin/gonymizer


### PR DESCRIPTION
I think the gonymizer stage in the Dockerfile probably doesn't need the golang image, it could probably use alpine directly for an even smaller build.