### PR TITLE
Allow quotes around TableName in COPY

### DIFF
--- a/concurrent.go
+++ b/concurrent.go
@@ -160,7 +160,7 @@ func createChunks(chunks chan<- Chunk, reader *bufio.Reader, wg *sync.WaitGroup,
 
 			trimmedInput := strings.TrimLeftFunc(input, unicode.IsSpace)
 			if strings.HasPrefix(trimmedInput, StateChangeTokenBeginCopy) {
-				pattern := `^COPY (?P<Schema>[a-zA-Z_]+)\.(?P<TableName>\w+) \((?P<Columns>.*)\) .*`
+				pattern := `^COPY (?P<Schema>[a-zA-Z_]+)\."?(?P<TableName>\w+)"? \((?P<Columns>.*)\) .*`
 				r := regexp.MustCompile(pattern)
 				submatch := r.FindStringSubmatch(trimmedInput)
 				if len(submatch) == 0 {


### PR DESCRIPTION
Sometimes `pg_dump` will add quotes around the TableName, which results in a `Regex doesn't match: ...` error from gonymyzer.