### PR TITLE
adding oids option to support older pg_dump

### DIFF
--- a/args_builder.go
+++ b/args_builder.go
@@ -1,0 +1,64 @@
+package gonymizer
+
+import (
+	"fmt"
+	"strings"
+)
+
+
+func CreateDumpArgs(
+	conf PGConfig,
+	dumpfilePath,
+	schemaPrefix string,
+  excludeTables,
+	excludeDataTables,
+	excludeCreateSchemas,
+	schemas []string,
+	oids bool,
+) [] string {
+
+	args := []string{"--no-owner"}
+
+	if oids {
+    args = append(args, "--oids")
+	}
+
+	if len(schemas) >= 1 {
+		// Add all schemas that match schemaPrefix to the dump list
+		for _, s := range schemas {
+			if strings.HasPrefix(schemaPrefix, s) {
+				args = append(args, fmt.Sprintf("--schema=%s*.*", schemaPrefix))
+			} else {
+				args = append(args, fmt.Sprintf("--schema=%s.*", s))
+			}
+		}
+	}
+
+	// Exclude system schemas
+	for _, sch := range excludeCreateSchemas {
+		args = append(args, fmt.Sprintf("--exclude-schema=%s", sch))
+	}
+
+	// Exclude tables that are not needed (schema will not be dumped)
+	for _, tbl := range excludeTables {
+		// According to: https://www.postgresql.org/docs/9.3/static/app-pgdump.html we need to add a flag for every table
+		// unless we use a regex match which we do not want in this case. Make sure to read the NOTES under --table. They
+		// apply here as well.
+
+		// tbl format => "schema_name.table_name"
+		args = append(args, fmt.Sprintf("--exclude-table=%s", tbl))
+	}
+
+	// Exclude tables that we do not need data from (but keep the schema... restores a blank table)
+	for _, tbl := range excludeDataTables {
+		args = append(args, fmt.Sprintf("--exclude-table-data=%s", tbl))
+	}
+
+	args = append(args, "-f")
+	args = append(args, dumpfilePath)
+
+	// Always put URI last
+	args = append(args, conf.URI())
+
+	return args
+}

--- a/args_builder.go
+++ b/args_builder.go
@@ -10,7 +10,7 @@ func CreateDumpArgs(
 	conf PGConfig,
 	dumpfilePath,
 	schemaPrefix string,
-  excludeTables,
+	excludeTables,
 	excludeDataTables,
 	excludeCreateSchemas,
 	schemas []string,
@@ -20,7 +20,7 @@ func CreateDumpArgs(
 	args := []string{"--no-owner"}
 
 	if oids {
-    args = append(args, "--oids")
+		args = append(args, "--oids")
 	}
 
 	if len(schemas) >= 1 {

--- a/args_builder_test.go
+++ b/args_builder_test.go
@@ -44,7 +44,7 @@ func TestCanProvideSchemas(t *testing.T) {
 		no_oids_flag,
 	)
 	expected_args := []string{
-  	"--no-owner",
+		"--no-owner",
 		"--schema=schema1.*",
 		"--schema=schema2.*",
 		"-f", "testing/output.TestCreateFile.sql",
@@ -67,7 +67,7 @@ func TestSchemaPrefixAddsWildcard(t *testing.T) {
 		no_oids_flag,
 	)
 	expected_args := []string{
-  	"--no-owner",
+		"--no-owner",
 		"--schema=company_*.*",
 		"-f", "testing/output.TestCreateFile.sql",
 		"postgres://postgres:postgres@localhost/gon_test_db?sslmode=disable",
@@ -89,7 +89,7 @@ func TestCanExcludeSchemas(t *testing.T) {
 		no_oids_flag,
 	)
 	expected_args := []string{
-  	"--no-owner",
+	 	"--no-owner",
 		"--exclude-schema=bad-schema1",
 		"--exclude-schema=bad-schema2",
 		"--exclude-schema=bad-schema3",
@@ -113,7 +113,7 @@ func TestCanExcludeTables(t *testing.T) {
 		no_oids_flag,
 	)
 	expected_args := []string{
-  	"--no-owner",
+		"--no-owner",
 		"--exclude-table=bad-table1",
 		"--exclude-table=bad-table2",
 		"-f", "testing/output.TestCreateFile.sql",
@@ -136,7 +136,7 @@ func TestCanExcludeTableData(t *testing.T) {
 		no_oids_flag,
 	)
 	expected_args := []string{
-  	"--no-owner",
+		"--no-owner",
 		"--exclude-table-data=bad-table1",
 		"--exclude-table-data=bad-table2",
 		"-f", "testing/output.TestCreateFile.sql",
@@ -156,10 +156,10 @@ func TestCanAddOIDSFlag(t *testing.T) {
 		emptyList,
 		emptyList,
 		emptyList,
-	  oids_flag_present,
+		oids_flag_present,
 	)
 	expected_args := []string{
-  	"--no-owner",
+		"--no-owner",
 		"--oids",
 		"-f", "testing/output.TestCreateFile.sql",
 		"postgres://postgres:postgres@localhost/gon_test_db?sslmode=disable",

--- a/args_builder_test.go
+++ b/args_builder_test.go
@@ -1,0 +1,169 @@
+package gonymizer
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+var emptyList = []string{}
+const no_oids_flag = false
+const oids_flag_present = true
+
+func TestMinimalDumpArgs(t *testing.T) {
+	conf := GetTestDbConf(TestDb)
+	args := CreateDumpArgs(
+		conf,
+		TestCreateFile,
+		TestSchemaPrefix,
+		emptyList,
+		emptyList,
+		emptyList,
+		emptyList,
+		no_oids_flag,
+	)
+	expected_args := []string{
+		"--no-owner",
+		"-f", "testing/output.TestCreateFile.sql",
+		"postgres://postgres:postgres@localhost/gon_test_db?sslmode=disable",
+	}
+
+  assert.Equal(t, expected_args, args, "they should be equal")
+}
+
+
+func TestCanProvideSchemas(t *testing.T) {
+	conf := GetTestDbConf(TestDb)
+	args := CreateDumpArgs(
+		conf,
+		TestCreateFile,
+		TestSchemaPrefix,
+		emptyList,
+		emptyList,
+		emptyList,
+		[]string{"schema1", "schema2"},
+		no_oids_flag,
+	)
+	expected_args := []string{
+  	"--no-owner",
+		"--schema=schema1.*",
+		"--schema=schema2.*",
+		"-f", "testing/output.TestCreateFile.sql",
+		"postgres://postgres:postgres@localhost/gon_test_db?sslmode=disable",
+	}
+
+  assert.Equal(t, expected_args, args, "they should be equal")
+}
+
+func TestSchemaPrefixAddsWildcard(t *testing.T) {
+	conf := GetTestDbConf(TestDb)
+	args := CreateDumpArgs(
+		conf,
+		TestCreateFile,
+		"company_",
+		emptyList,
+		emptyList,
+		emptyList,
+		[]string{"company"},
+		no_oids_flag,
+	)
+	expected_args := []string{
+  	"--no-owner",
+		"--schema=company_*.*",
+		"-f", "testing/output.TestCreateFile.sql",
+		"postgres://postgres:postgres@localhost/gon_test_db?sslmode=disable",
+	}
+
+  assert.Equal(t, expected_args, args, "they should be equal")
+}
+
+func TestCanExcludeSchemas(t *testing.T) {
+	conf := GetTestDbConf(TestDb)
+	args := CreateDumpArgs(
+		conf,
+		TestCreateFile,
+		TestSchemaPrefix,
+		emptyList,
+		emptyList,
+		[]string{"bad-schema1", "bad-schema2", "bad-schema3"},
+		emptyList,
+		no_oids_flag,
+	)
+	expected_args := []string{
+  	"--no-owner",
+		"--exclude-schema=bad-schema1",
+		"--exclude-schema=bad-schema2",
+		"--exclude-schema=bad-schema3",
+		"-f", "testing/output.TestCreateFile.sql",
+		"postgres://postgres:postgres@localhost/gon_test_db?sslmode=disable",
+	}
+
+  assert.Equal(t, expected_args, args, "they should be equal")
+}
+
+func TestCanExcludeTables(t *testing.T) {
+	conf := GetTestDbConf(TestDb)
+	args := CreateDumpArgs(
+		conf,
+		TestCreateFile,
+		TestSchemaPrefix,
+		[]string{"bad-table1", "bad-table2"},
+		emptyList,
+		emptyList,
+		emptyList,
+		no_oids_flag,
+	)
+	expected_args := []string{
+  	"--no-owner",
+		"--exclude-table=bad-table1",
+		"--exclude-table=bad-table2",
+		"-f", "testing/output.TestCreateFile.sql",
+		"postgres://postgres:postgres@localhost/gon_test_db?sslmode=disable",
+	}
+
+  assert.Equal(t, expected_args, args, "they should be equal")
+}
+
+func TestCanExcludeTableData(t *testing.T) {
+	conf := GetTestDbConf(TestDb)
+	args := CreateDumpArgs(
+		conf,
+		TestCreateFile,
+		TestSchemaPrefix,
+		emptyList,
+		[]string{"bad-table1", "bad-table2"},
+		emptyList,
+		emptyList,
+		no_oids_flag,
+	)
+	expected_args := []string{
+  	"--no-owner",
+		"--exclude-table-data=bad-table1",
+		"--exclude-table-data=bad-table2",
+		"-f", "testing/output.TestCreateFile.sql",
+		"postgres://postgres:postgres@localhost/gon_test_db?sslmode=disable",
+	}
+
+  assert.Equal(t, expected_args, args, "they should be equal")
+}
+
+func TestCanAddOIDSFlag(t *testing.T) {
+	conf := GetTestDbConf(TestDb)
+	args := CreateDumpArgs(
+		conf,
+		TestCreateFile,
+		TestSchemaPrefix,
+		emptyList,
+		emptyList,
+		emptyList,
+		emptyList,
+	  oids_flag_present,
+	)
+	expected_args := []string{
+  	"--no-owner",
+		"--oids",
+		"-f", "testing/output.TestCreateFile.sql",
+		"postgres://postgres:postgres@localhost/gon_test_db?sslmode=disable",
+	}
+
+  assert.Equal(t, expected_args, args, "they should be equal")
+}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -144,6 +144,15 @@ func init() {
 	)
 	_ = viper.BindPFlag("dump.username", DumpCmd.Flags().Lookup("username"))
 
+	DumpCmd.Flags().BoolVarP(
+		&enableOIDS,
+		"oids",
+		"o",
+		false,
+		"Enable --oids option for older versions of pg_dump",
+	)
+	_ = viper.BindPFlag("dump.oids", DumpCmd.Flags().Lookup("oids"))
+
 }
 
 // cliCommandDump verifies that the supplied configuration is correct and starts the Dump process. If there is an error
@@ -217,6 +226,7 @@ func cliCommandDump(cmd *cobra.Command, args []string) {
 		viper.GetStringSlice("dump.exclude-table-data"),
 		viper.GetStringSlice("dump.exclude-schema"),
 		viper.GetStringSlice("dump.schema"),
+		viper.GetBool("dump.oids"),
 	)
 
 	if err != nil {
@@ -237,6 +247,7 @@ func dump(
 	excludeTableData,
 	excludeSchemas,
 	schema []string,
+	oids bool,
 ) (err error) {
 	return gonymizer.CreateDumpFile(
 		conf,
@@ -246,6 +257,7 @@ func dump(
 		excludeTableData,
 		excludeSchemas,
 		schema,
+		oids,
 	)
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,6 +76,7 @@ var (
 	schemaPrefix     string
 	s3File           string
 	schema           []string
+	enableOIDS       bool
 
 	rootCmd = &cobra.Command{
 		Use:              "gonymizer",

--- a/generator.go
+++ b/generator.go
@@ -54,6 +54,7 @@ func CreateDumpFile(
 	excludeDataTables,
 	excludeCreateSchemas,
 	schemas []string,
+	oids bool,
 ) error {
 
 	var (
@@ -61,49 +62,9 @@ func CreateDumpFile(
 		outBuffer bytes.Buffer
 	)
 
+	args := CreateDumpArgs(conf, dumpfilePath, schemaPrefix, excludeTables, excludeDataTables, excludeCreateSchemas, schemas, oids)
+
 	cmd := "pg_dump"
-	args := []string{
-		"--oids",
-		"--no-owner",
-	}
-
-	if len(schemas) >= 1 {
-		// Add all schemas that match schemaPrefix to the dump list
-		for _, s := range schemas {
-			if strings.HasPrefix(schemaPrefix, s) {
-				args = append(args, fmt.Sprintf("--schema=%s*.*", schemaPrefix))
-			} else {
-				args = append(args, fmt.Sprintf("--schema=%s.*", s))
-			}
-		}
-	}
-
-	// Exclude system schemas
-	for _, sch := range excludeCreateSchemas {
-		args = append(args, fmt.Sprintf("--exclude-schema=%s", sch))
-	}
-
-	// Exclude tables that are not needed (schema will not be dumped)
-	for _, tbl := range excludeTables {
-		// According to: https://www.postgresql.org/docs/9.3/static/app-pgdump.html we need to add a flag for every table
-		// unless we use a regex match which we do not want in this case. Make sure to read the NOTES under --table. They
-		// apply here as well.
-
-		// tbl format => "schema_name.table_name"
-		args = append(args, fmt.Sprintf("--exclude-table=%s", tbl))
-	}
-
-	// Exclude tables that we do not need data from (but keep the schema... restores a blank table)
-	for _, tbl := range excludeDataTables {
-		args = append(args, fmt.Sprintf("--exclude-table-data=%s", tbl))
-	}
-
-	args = append(args, "-f")
-	args = append(args, dumpfilePath)
-
-	// Always put URI last
-	args = append(args, conf.URI())
-
 	// Execute pg_dump
 	err := ExecPostgresCommandOutErr(&outBuffer, &errBuffer, cmd, args...)
 	if err != nil {

--- a/generator_test.go
+++ b/generator_test.go
@@ -23,7 +23,7 @@ func TestCreateDumpFile(t *testing.T) {
 		  TestExcludeSchemas,
 		  TestSchemas,
 		  TestOIDSEnabled,
-  	),
+	),
   )
 
 	// Check dump file size
@@ -54,7 +54,7 @@ func TestProcessDumpFile(t *testing.T) {
 		  TestExcludeSchemas,
 		  TestSchemas,
 		  TestOIDSEnabled,
- 	  ),
+		),
   )
 
 	// Generate a processed dump file

--- a/generator_test.go
+++ b/generator_test.go
@@ -12,17 +12,19 @@ import (
 func TestCreateDumpFile(t *testing.T) {
 	conf := GetTestDbConf(TestDb)
 
+
 	require.Nil(t,
-		CreateDumpFile(
-			conf,
-			TestCreateFile,
-			TestSchemaPrefix,
-			TestExcludeTable,
-			TestExcludeTableData,
-			TestExcludeSchemas,
-			TestSchemas,
-		),
-	)
+	  CreateDumpFile(
+		  conf,
+		  TestCreateFile,
+		  TestSchemaPrefix,
+		  TestExcludeTable,
+		  TestExcludeTableData,
+		  TestExcludeSchemas,
+		  TestSchemas,
+		  TestOIDSEnabled,
+  	),
+  )
 
 	// Check dump file size
 	size, err := ioutil.ReadFile(TestCreateFile)
@@ -43,16 +45,17 @@ func TestProcessDumpFile(t *testing.T) {
 
 	// Create a dump file from our test database
 	require.Nil(t,
-		CreateDumpFile(
-			conf,
-			TestDumpFile,
-			TestSchemaPrefix,
-			TestExcludeTable,
-			TestExcludeTableData,
-			TestExcludeSchemas,
-			TestSchemas,
-		),
-	)
+	  CreateDumpFile(
+		  conf,
+		  TestCreateFile,
+		  TestSchemaPrefix,
+		  TestExcludeTable,
+		  TestExcludeTableData,
+		  TestExcludeSchemas,
+		  TestSchemas,
+		  TestOIDSEnabled,
+ 	  ),
+  )
 
 	// Generate a processed dump file
 	columnMap, err := LoadConfigSkeleton(TestMapFile)

--- a/main_test.go
+++ b/main_test.go
@@ -188,7 +188,6 @@ func seqUnitTests(t *testing.T) {
 	t.Run("PostProcess", TestPostProcess)
 	t.Run("Clear", TestClear)
 
-
 	// Test loader.go
 	t.Run("LoadFile", TestLoadFile)
 	t.Run("TempDbCreate", TestLoaderTempDbCreation)

--- a/main_test.go
+++ b/main_test.go
@@ -39,6 +39,8 @@ const TestProcessDumpfile = "testing/output.TestProcessDumpFile.sql"
 // Test schemaPrefix
 const TestSchemaPrefix = ""
 
+const TestOIDSEnabled = false
+
 // Test tables, exclude tables, and schemas
 var (
 	TestExcludeTable     = []string{"distributors"}
@@ -63,6 +65,7 @@ func GetTestDbConf(dbName string) PGConfig {
 	}
 	conf := PGConfig{}
 	conf.Username = os.Getenv("POSTGRES_USER")
+	conf.Pass = os.Getenv("POSTGRES_PASSWORD")
 	conf.Host = host
 	conf.DefaultDBName = dbName
 	conf.SSLMode = "disable"
@@ -112,6 +115,15 @@ func TestStart(t *testing.T) {
 // For example: CREATE/DROP DB should follow each other
 // NOTE: ORDER MATTERS HERE FOR TESTS
 func seqUnitTests(t *testing.T) {
+	//args_builder.go
+	t.Run("MinimalDumpArgs", TestMinimalDumpArgs)
+	t.Run("CanExcludeSchemas", TestCanExcludeSchemas)
+	t.Run("CanProvideSchema", TestCanProvideSchemas)
+	t.Run("SchemaPrefixAddsWildcard", TestSchemaPrefixAddsWildcard)
+	t.Run("CanExcludeTables", TestCanExcludeTables)
+	t.Run("CanExcludeTableData", TestCanExcludeTableData)
+	t.Run("CanAddOIDSFlag", TestCanAddOIDSFlag)
+
 	t.Run("DSN", TestDSN)
 	t.Run("BaseDSN", TestBaseDSN)
 	t.Run("URI", TestURI)
@@ -175,6 +187,7 @@ func seqUnitTests(t *testing.T) {
 	t.Run("ProcessDumpFile", TestProcessDumpFile)
 	t.Run("PostProcess", TestPostProcess)
 	t.Run("Clear", TestClear)
+
 
 	// Test loader.go
 	t.Run("LoadFile", TestLoadFile)


### PR DESCRIPTION
I've added an option for the dump section for the --oids pg_dump option

since pg_dump 12, this option hasn't been present and causes the gonymizer dump to fail in pg_dump 12/13


@junkert I split out arg_building, happy to revert that if you prefer!

the other thing i would mention that I'm not sure about is that in my pg_dump script (outside gonymizer) i'm passing -x, do we need to support that also? I'm not an expert on pg_dump!

Dan