### PR TITLE
Fix master CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           PGDATABASE: circleci
           PGPASSWORD: circleci
           PGHOST: 127.0.0.1
-      - image: circleci/postgres:10.7-alpine
+      - image: cimg/postgres:13.4
         environment:
           POSTGRES_PASSWORD: circleci
           POSTGRES_USER: circleci


### PR DESCRIPTION
Hi, this bumps the postgresql docker image for circle to be the more recent version required by the tests following the --oids flag addition!