### PR TITLE
Add optional Exemptions regex to column map definition

### DIFF
--- a/docs/demos/dellstore2/db_map.json
+++ b/docs/demos/dellstore2/db_map.json
@@ -230,7 +230,8 @@
                     "Max": 0,
                     "Min": 0,
                     "Variance": 0,
-                    "Comment": ""
+                    "Comment": "",
+                    "Excemptions": "skip.*me"
                 }
             ]
         },

--- a/generator.go
+++ b/generator.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	mathRand "math/rand"
 	"os"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -367,7 +368,24 @@ func processValue(cmap *ColumnMapper, input string) (string, error) {
 
 		}
 
+		if procDef.Exemptions != "" {
+			expression, err := regexp.Compile(procDef.Exemptions)
+			if err != nil {
+				log.Error(err)
+				log.Error("Invalid Exemptions expression: ", procDef.Name)
+				log.Debug("i: ", i)
+				log.Debug("cmap: ", cmap)
+				log.Debug("input: ", input)
+				return "", err
+			}
+
+			if expression.MatchString(input) {
+				return input, nil
+			}
+		}
+
 		output, err = pfunc(cmap, input)
+
 		if err != nil {
 			log.Error(err)
 			log.Debug("i: ", i)

--- a/mapper.go
+++ b/mapper.go
@@ -20,6 +20,9 @@ type ProcessorDefinition struct {
 	Min      float64
 	Variance float64
 
+	// values that match this regex will not be anonymized
+	Exemptions string
+
 	Comment string
 }
 


### PR DESCRIPTION
My use case is.. 

I want to exclude all email addresses in my domain from being transformed. 

We anonymize Prod and copy to Staging. Our employees have data in Prod, but loose their accounts in Staging. 
By excluding their emails from being anonymized, they can log in with their existing creds in Staging... but all our customer data is hidden.