### PR TITLE
Correct the v2.0.0 entry in the CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
-=======
-## [v2.0.0)(https://github.com/smithoss/gonymizer/releases/tag/v1.2.0) 9/04/2020
+
+## [v2.0.0](https://github.com/smithoss/gonymizer/releases/tag/v2.0.0) 9/04/2020
 * Multithreaded processing is now available. Please see the updated --help flag for new cli arguments.
 
 ## [v1.2.0](https://github.com/smithoss/gonymizer/releases/tag/v1.2.0) 7/31/2019


### PR DESCRIPTION
The entry's Markdown syntax was broken, and the link incorrectly going to v1.2.0 instead of v2.0.0.