### PR TITLE
Correct the pg_dump --schema arg format

### DIFF
--- a/args_builder.go
+++ b/args_builder.go
@@ -26,9 +26,9 @@ func CreateDumpArgs(
 		// Add all schemas that match schemaPrefix to the dump list
 		for _, s := range schemas {
 			if strings.HasPrefix(schemaPrefix, s) {
-				args = append(args, fmt.Sprintf("--schema=%s*.*", schemaPrefix))
+				args = append(args, fmt.Sprintf("--schema=%s*", schemaPrefix))
 			} else {
-				args = append(args, fmt.Sprintf("--schema=%s.*", s))
+				args = append(args, fmt.Sprintf("--schema=%s", s))
 			}
 		}
 	}

--- a/args_builder_test.go
+++ b/args_builder_test.go
@@ -45,8 +45,8 @@ func TestCanProvideSchemas(t *testing.T) {
 	)
 	expected_args := []string{
 		"--no-owner",
-		"--schema=schema1.*",
-		"--schema=schema2.*",
+		"--schema=schema1",
+		"--schema=schema2",
 		"-f", "testing/output.TestCreateFile.sql",
 		"postgres://user:password@test_host/db_name?sslmode=disable",
 	}
@@ -68,7 +68,7 @@ func TestSchemaPrefixAddsWildcard(t *testing.T) {
 	)
 	expected_args := []string{
 		"--no-owner",
-		"--schema=company_*.*",
+		"--schema=company_*",
 		"-f", "testing/output.TestCreateFile.sql",
 		"postgres://user:password@test_host/db_name?sslmode=disable",
 	}


### PR DESCRIPTION
The args to `pg_dump`'s `--schema` option are schema-name patterns, not table-name patterns.

For example, consider a Gonymizer config with: `schema": ["foo", "bar"]`

Prior to this change, the resulting `pg_dump` will look like:

```
pg_dump ... --schema foo.* --schema bar.* ...
```

The result is that `pd_dump` interprets `foo` and `bar` as database names with the `*` schemas, and, consequently, dumps *all* tables in the current databse.

After this change, the same config results in:

```
pg_dump ... --schema foo --schema bar ...
```
Which dumps just the `foo` and `bar` schemas, as expected.

Note, as per issue #112, `pg_dump` v14 will actually refuse to run with the existing incorrect arguments.  But while v13 will not complain, it does (as explained above) do the wrong thing. This change resolves #112 as a convenient side-affect.

Also worth noting, `pg_dump`'s `--exclude-schema` option accepts the same format, but Gonymizer already does the right thing there 🙂